### PR TITLE
Make /()/new use lwt

### DIFF
--- a/src/logarion.ml
+++ b/src/logarion.ml
@@ -19,9 +19,11 @@ let of_file s =
     { blank_ymd with body = "Error parsing file" }
 
 let to_file ymd =
-  let oc = open_out ("ymd/" ^ (filename ymd))  in
-  Printf.fprintf oc "%s" (to_string ymd);
-  close_out oc
+  let open Lwt.Infix in
+  let path = "ymd/" ^ (filename ymd) in
+  Lwt_io.with_file ~mode:Lwt_io.output path  (fun out ->
+      Lwt_io.write out (to_string ymd)
+    )
 
 let titled_files () =
   let files = Array.to_list @@ Sys.readdir "ymd/" in

--- a/src/web.ml
+++ b/src/web.ml
@@ -8,14 +8,18 @@ let ymd_of_body_pairs pairs =
   ListLabels.fold_left ~f:(fun a (k,vl) -> with_kv a (k, List.hd vl) ) ~init:blank_ymd pairs
   |> ((ymd_meta |-- meta_date |-- date_edited) ^= Some (Ptime_clock.now ()))
 
-let ymd_of_req req = ymd_of_body_pairs (Lwt_main.run @@ App.urlencoded_pairs_of_body req)
+let ymd_of_req req =
+  Lwt.map ymd_of_body_pairs (App.urlencoded_pairs_of_body req)
 
 let string_response s = `String s |> respond'
 let html_response h = `Html h |> respond'
 
 let () =
   App.empty
-  |> post "/()/new"   (fun req -> let ymd = ymd_of_req req in Logarion.to_file ymd; `Html (Html.of_ymd ymd) |> respond')
+  |> post "/()/new"  (fun req ->
+      ymd_of_req req >>= fun ymd ->
+      Logarion.to_file ymd >>= fun () ->
+      `Html (Html.of_ymd ymd) |> respond')
   |> get "/:ttl"      (fun req -> param req "ttl" |> ymdpath |> Logarion.of_file |> Html.of_ymd |> html_response)
   |> get "/:ttl/edit" (fun req -> param req "ttl" |> ymdpath |> Logarion.of_file |> Html.form   |> html_response)
   |> get "/style.css" (fun _   -> "ymd/style.css" |> Logarion.load_file |> string_response)


### PR DESCRIPTION
Since opium uses Lwt, apps written in opium should use lwt for all
IO (and other possibly blocking operations). Lwt_main.run simply runs
lwt's event loop so it should usually be called once in a program.

Other endpoints can be converted similarly by first converting
`Logarion.of_file`